### PR TITLE
Fix css rule to affect only eos.md, ethereum.md, bitcoin.md

### DIFF
--- a/_sass/layout/_sidepanel.scss
+++ b/_sass/layout/_sidepanel.scss
@@ -12,7 +12,7 @@
     overflow-y: auto;
     top: 50%;
 
-    & ~ .article .container h3 {
+    & ~ .article .container h1#assets-management-tools ~ h3{
         display: inline-block;
         & + p {
             display: inline-block;


### PR DESCRIPTION
Change selector to affect only pages with icons inside `<p>` after `<h3>` (photo). 
It makes `<h3>` and first `<p>` after `<h3>` `display:inline-block`.
![image](https://user-images.githubusercontent.com/14793248/64918000-645bfc80-d7a0-11e9-8300-2974af52cee9.png)
